### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3'
 
 services:
   db:


### PR DESCRIPTION
My Docker has a problem with 3.8... But 3 works. Wouldn't it be more universal if we changed to integer instead of floating point?